### PR TITLE
fix pb described in "ToggleSet out of sync when a new TV is added #5" 

### DIFF
--- a/core/components/toggletvset/elements/plugins/toggletvset.plugin.php
+++ b/core/components/toggletvset/elements/plugins/toggletvset.plugin.php
@@ -20,6 +20,8 @@ $toggletvset = $modx->getService('toggletvset', 'ToggleTVSet', $corePath . 'mode
 
 switch ($eventName) {
     case 'OnDocFormPrerender':
-        $toggletvset->includeScriptAssets();
+        if ($toggletvset->ready()) {
+            $toggletvset->includeScriptAssets();
+        }
         break;
 };

--- a/core/components/toggletvset/elements/snippets/gettvlabel.snippet.php
+++ b/core/components/toggletvset/elements/snippets/gettvlabel.snippet.php
@@ -20,7 +20,21 @@ $output = '';
 foreach ($elements as $key => $element) {
     $element = explode('==', $element);
 
-    if ($element[1] == $input) {
+    $value = $element[1];
+    
+	if (strpos($value,'[[') !== false)
+	{
+		$uniqid = uniqid();
+		$chunk = $modx->newObject('modChunk', array('name' => "{tmp}-{$uniqid}"));
+		$chunk->setCacheable(false);
+		$value = $chunk->process(array(), $value);
+		$modx->getParser();
+		/*parse all non-cacheable tags and remove unprocessed tags - if you want to parse cacheable tags set 3 param as false*/
+		$modx->parser->processElementTags('', $value, true, true, '[[', ']]', array(), 0);
+	}
+
+
+    if ($value == $input) {
         $output = $element[0];
         break;
     }

--- a/core/components/toggletvset/elements/snippets/gettvlabel.snippet.php
+++ b/core/components/toggletvset/elements/snippets/gettvlabel.snippet.php
@@ -20,7 +20,7 @@ $output = '';
 foreach ($elements as $key => $element) {
     $element = explode('==', $element);
 
-    $value = array_key_exists(1,$element) ? $element[1] : '';
+    $value = isset($element[1]) ? $element[1] : '';
     
 	if (strpos($value,'[[') !== false)
 	{

--- a/core/components/toggletvset/elements/snippets/gettvlabel.snippet.php
+++ b/core/components/toggletvset/elements/snippets/gettvlabel.snippet.php
@@ -20,7 +20,7 @@ $output = '';
 foreach ($elements as $key => $element) {
     $element = explode('==', $element);
 
-    $value = $element[1];
+    $value = array_key_exists(1,$element) ? $element[1] : '';
     
 	if (strpos($value,'[[') !== false)
 	{

--- a/core/components/toggletvset/model/toggletvset/toggletvset.class.php
+++ b/core/components/toggletvset/model/toggletvset/toggletvset.class.php
@@ -6,7 +6,7 @@
  * Copyright 2015-2019 by Thomas Jakobi <thomas.jakobi@partout.info>
  * Modifications:
  * - Emmanuel Podvin - Intersel - 20190901 -
- *      add modx parsing on the input options values of the Toggle TV 
+ *      add modx parsing on the input options values of the Toggle TV
  *      in order to prevent problem described in https://github.com/Jako/ToggleTVSet/issues/5
  *
  * @package toggletvset
@@ -47,6 +47,8 @@ class ToggleTVSet
      * @var array $options
      */
     public $options = array();
+
+		private $ready = false;
 
     /**
      * ToggleTVSet constructor
@@ -100,6 +102,19 @@ class ToggleTVSet
             $toggletv = intval($toggletv);
             $tv = $this->modx->getObject('modTemplateVar', $toggletv);
 
+						// Is our toggle tv is set for the template of our ressource?
+						$tvt = $this->modx->getObject('modTemplateVarTemplate', array(
+											'tmplvarid' => $toggletv,
+											'templateid' => $this->modx->resource->get('template')
+						));
+						if (empty($tvt))
+						{
+							continue;//the toggle TV is not in the template of the ressource => should do nothing...
+						}
+
+						$this->ready = true;//ok
+
+
             if ($tv) {
                 $elements = $tv->get('elements');
                 $elements = explode('||', $elements);
@@ -125,14 +140,15 @@ class ToggleTVSet
                 }
                 $hidetvs = array_values(array_unique($hidetvs));
                 if ($this->modx->resource) {
-                    $tvr = $modx->getObject('modTemplateVarResource', array(
+
+                    $tvr = $this->modx->getObject('modTemplateVarResource', array(
                         'tmplvarid' => $toggletv,
                         'contentid' => $this->modx->resource->get('id')
                     ));
                     if ($tvr) {
                         $tvvalue = $tvr->get('value');
                     } else {
-                        $tv = $modx->getObject('modTemplateVar', $toggletv);
+                        $tv = $this->modx->getObject('modTemplateVar', $toggletv);
                         $tvvalue = ($tv) ? $tv->get('default_text') : '';
                     }
                     if ($tvvalue) {
@@ -214,6 +230,15 @@ class ToggleTVSet
         }
         return (bool)$value;
     }
+
+/**
+ * returns if we can include the script...
+ * @return boolean if true it's ok to install the script
+ */
+		public function ready()
+		{
+			return $this->ready;
+		}
 
     /**
      * Register javascripts in the controller

--- a/source/js/mgr/toggletvset.js
+++ b/source/js/mgr/toggletvset.js
@@ -25,8 +25,8 @@ Ext.onReady(function () {
             hideTVs = tv.hideTVs;
             showTVs = tv.showTVs;
         } else {
-            hideTVs = tv.store.data.keys.join().split(',');
-            showTVs = tv.getValue().split(',');
+            hideTVs = ToggleTVSet.options.hideTVs;//tv.store.data.keys.join().split(',');
+            showTVs = ToggleTVSet.options.showOptionTvs[tv.selectedIndex].split(',');//tv.getValue().split(',');
         }
 
         ToggleTVSet.toggleTVSet(hideTVs, 0);
@@ -77,3 +77,4 @@ Ext.onReady(function () {
         ToggleTVSet.options.initialized = true;
     });
 });
+


### PR DESCRIPTION
As the option values were not parsed, the toggle did not work when using chunks or snippets to output the comma separated tv list.

as in the example of the issue described in "ToggleSet out of sync when a new TV is added #5" ,

`Please select...==||Event==[[$TVSetEvent]]||Coming Soon==[[$TVSetComing]]` 

is now working as expected...

This pull request fixes this problem by parsing the input values if they are chunks or snippets to produce a "display"/"hidden" tv array for EXTJs according to the selected item in the combo box of the ToggleTVset.

more testing than I did is surely to be done...